### PR TITLE
Adding support for disco series

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,6 +7,7 @@ description: |
 tags:
   - network
 series:
+  - disco
   - bionic
   - xenial
 provides:


### PR DESCRIPTION
The addition of 'disco' in metadata.yaml will allow the use of this
charm for disco series.
Fixing https://github.com/openstack-charmers/charm-quagga/issues/18 